### PR TITLE
Removed "milyn" from artifact ID since the name is deprecated; using …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.milyn.cartridges.dfdl</groupId>
-    <artifactId>smooks-cartridge-dfdl</artifactId>
+    <artifactId>smooks-dfdl-cartridge</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.milyn.cartridges.dfdl</groupId>
-    <artifactId>milyn-smooks-dfdl</artifactId>
+    <artifactId>smooks-cartridge-dfdl</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>

--- a/src/main/java/org/milyn/cartridges/dfdl/DFDLUnparser.java
+++ b/src/main/java/org/milyn/cartridges/dfdl/DFDLUnparser.java
@@ -18,13 +18,9 @@ import org.milyn.delivery.ordering.Producer;
 import org.milyn.xml.DomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayOutputStream;
 import java.nio.channels.Channels;
 import java.util.Set;
@@ -55,21 +51,9 @@ public class DFDLUnparser implements DOMVisitAfter, ContentDeliveryConfigBuilder
     }
 
     @Override
-    public void visitAfter(Element element, ExecutionContext executionContext) throws SmooksException {
-        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setNamespaceAware(true);
-        final DocumentBuilder builder;
-        try {
-            builder = factory.newDocumentBuilder();
-        } catch (ParserConfigurationException e) {
-            throw new SmooksException(e.getMessage(), e);
-        }
-        final Document newDocument = builder.newDocument();
-        final Node importedNode = newDocument.importNode(element, true);
-        newDocument.appendChild(importedNode);
-
+    public void visitAfter(final Element element, final ExecutionContext executionContext) throws SmooksException {
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        final UnparseResult unparseResult = dataProcessor.unparse(new W3CDOMInfosetInputter(newDocument), Channels.newChannel(byteArrayOutputStream));
+        final UnparseResult unparseResult = dataProcessor.unparse(new W3CDOMInfosetInputter(element.getOwnerDocument()), Channels.newChannel(byteArrayOutputStream));
         for (Diagnostic diagnostic : unparseResult.getDiagnostics()) {
             if (diagnostic.isError()) {
                 throw new SmooksException(diagnostic.getSomeMessage(), diagnostic.getSomeCause());

--- a/src/main/java/org/milyn/cartridges/dfdl/delivery/AbstractDFDLContentHandlerFactory.java
+++ b/src/main/java/org/milyn/cartridges/dfdl/delivery/AbstractDFDLContentHandlerFactory.java
@@ -4,7 +4,6 @@ import org.apache.daffodil.japi.Daffodil;
 import org.apache.daffodil.japi.DataProcessor;
 import org.apache.daffodil.japi.Diagnostic;
 import org.apache.daffodil.japi.ProcessorFactory;
-import org.milyn.SmooksException;
 import org.milyn.cartridges.dfdl.DFDLParser;
 import org.milyn.cdr.SmooksConfigurationException;
 import org.milyn.cdr.SmooksResourceConfiguration;
@@ -12,14 +11,11 @@ import org.milyn.cdr.annotation.AppContext;
 import org.milyn.container.ApplicationContext;
 import org.milyn.delivery.ContentHandler;
 import org.milyn.delivery.ContentHandlerFactory;
-import org.milyn.resource.URIResourceLocator;
-import org.milyn.util.ClassUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,46 +29,43 @@ public abstract class AbstractDFDLContentHandlerFactory implements ContentHandle
 
     public ContentHandler create(final SmooksResourceConfiguration resourceConfig) throws SmooksConfigurationException {
         try {
-
-            if (applicationContext.getAttribute(AbstractDFDLContentHandlerFactory.class) == null) {
-                synchronized (DFDLParser.class) {
-                    if (applicationContext.getAttribute(AbstractDFDLContentHandlerFactory.class) == null) {
-                        applicationContext.setAttribute(AbstractDFDLContentHandlerFactory.class, new ConcurrentHashMap<>());
-                    }
-                }
-            }
-            final Map<String, DataProcessor> schemas = (Map<String, DataProcessor>) applicationContext.getAttribute(AbstractDFDLContentHandlerFactory.class);
-            final DataProcessor dataProcessor = schemas.computeIfAbsent(resourceConfig.getParameter("schemaURI").getValue(), k -> compileSchema(k, resourceConfig.getBoolParameter("validateDFDLSchemas", false)));
-
-            return doCreate(resourceConfig, dataProcessor);
+            final String schemaURI = resourceConfig.getParameter("schemaURI").getValue();
+            final DataProcessor dataProcessor = compileOrGet(schemaURI, schemaURI, resourceConfig.getBoolParameter("validateDFDLSchemas", false));
+            return doCreate(resourceConfig, schemaURI, dataProcessor);
         } catch (Throwable t) {
             throw new SmooksConfigurationException(t);
         }
     }
 
-    public abstract ContentHandler doCreate(SmooksResourceConfiguration resourceConfig, DataProcessor dataProcessor) throws SmooksConfigurationException;
+    public abstract ContentHandler doCreate(SmooksResourceConfiguration resourceConfig, String dataProcessorName, DataProcessor dataProcessor);
 
-    protected DataProcessor compileSchema(final String uriAsString, final boolean validateDFDLSchemas) {
-        try {
-            final URI uri = URI.create(uriAsString);
-            final URI newUri;
-            if (uri.getScheme().equals(URIResourceLocator.SCHEME_CLASSPATH)) {
-                final List<URL> resources = ClassUtil.getResources(uri.getRawSchemeSpecificPart(), DFDLParser.class);
-                if (resources.isEmpty()) {
-                    final IOException ioException = new IOException("Failed to read DFDL schema: " + uri);
-                    throw new SmooksException(ioException.getMessage(), ioException);
-                } else {
-                    newUri = resources.get(0).toURI();
+    protected DataProcessor compileOrGet(final String dataProcessorName, final String schemaUri, final boolean validateDFDLSchemas) throws Exception {
+        if (applicationContext.getAttribute(AbstractDFDLContentHandlerFactory.class) == null) {
+            synchronized (DFDLParser.class) {
+                if (applicationContext.getAttribute(AbstractDFDLContentHandlerFactory.class) == null) {
+                    applicationContext.setAttribute(AbstractDFDLContentHandlerFactory.class, new ConcurrentHashMap<>());
                 }
-            } else {
-                newUri = uri;
             }
+        }
+        final Map<String, DataProcessor> schemas = (Map<String, DataProcessor>) applicationContext.getAttribute(AbstractDFDLContentHandlerFactory.class);
+        final DataProcessor dataProcessor = schemas.computeIfAbsent(dataProcessorName, k -> {
+            try {
+                return compileSchema(new URI(schemaUri), validateDFDLSchemas);
+            } catch (URISyntaxException e) {
+                throw new SmooksConfigurationException(e);
+            }
+        });
 
+        return dataProcessor;
+    }
+
+    protected DataProcessor compileSchema(final URI uri, final boolean validateDFDLSchemas) {
+        try {
             LOGGER.info("Compiling and caching DFDL schema...");
             final org.apache.daffodil.japi.Compiler compiler = Daffodil.compiler();
             compiler.setValidateDFDLSchemas(validateDFDLSchemas);
 
-            final ProcessorFactory processorFactory = compiler.compileSource(newUri);
+            final ProcessorFactory processorFactory = compiler.compileSource(uri);
             if (processorFactory.isError()) {
                 final List<Diagnostic> diagnostics = processorFactory.getDiagnostics();
                 throw diagnostics.get(0).getSomeCause();

--- a/src/main/java/org/milyn/cartridges/dfdl/delivery/DFDLParserContentHandlerFactory.java
+++ b/src/main/java/org/milyn/cartridges/dfdl/delivery/DFDLParserContentHandlerFactory.java
@@ -9,7 +9,8 @@ import org.milyn.delivery.annotation.Resource;
 @Resource(type = "dfdl-parser")
 public class DFDLParserContentHandlerFactory extends AbstractDFDLContentHandlerFactory {
     @Override
-    public ContentHandler doCreate(final SmooksResourceConfiguration resourceConfig, final DataProcessor dataProcessor) throws SmooksConfigurationException {
+    public ContentHandler doCreate(final SmooksResourceConfiguration resourceConfig, final String dataProcessorName, final DataProcessor dataProcessor) throws SmooksConfigurationException {
+        resourceConfig.setParameter("dataProcessorName", dataProcessorName);
         resourceConfig.setResource("org.milyn.cartridges.dfdl.DFDLParser");
         return null;
     }

--- a/src/main/java/org/milyn/cartridges/dfdl/delivery/DFDLUnparserContentHandlerFactory.java
+++ b/src/main/java/org/milyn/cartridges/dfdl/delivery/DFDLUnparserContentHandlerFactory.java
@@ -11,7 +11,7 @@ import org.milyn.delivery.annotation.Resource;
 @Resource(type = "dfdl-unparser")
 public class DFDLUnparserContentHandlerFactory extends AbstractDFDLContentHandlerFactory {
     @Override
-    public ContentHandler doCreate(final SmooksResourceConfiguration resourceConfig, final DataProcessor dataProcessor) throws SmooksConfigurationException {
+    public ContentHandler doCreate(final SmooksResourceConfiguration resourceConfig, final String dataProcessorName, final DataProcessor dataProcessor) throws SmooksConfigurationException {
         return Configurator.configure(new DFDLUnparser(dataProcessor), resourceConfig, applicationContext);
     }
 }

--- a/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd
+++ b/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd
@@ -34,21 +34,8 @@
         </xsd:annotation>
         <xsd:complexContent>
             <xsd:extension base="smooks:abstract-reader">
-                <xsd:attribute name="schemaURI" type="xsd:string" use="required">
-                    <xsd:annotation>
-                        <xsd:documentation xml:lang="en">
-                            The URI of the DFDL schema.
-                        </xsd:documentation>
-                    </xsd:annotation>
-                </xsd:attribute>
-                <xsd:attribute name="validateDFDLSchemas" type="xsd:boolean" default="false">
-                    <xsd:annotation>
-                        <xsd:documentation xml:lang="en">
-                            Enable/disable DFDL validation of resulting infoset with the DFDL schema. Default is
-                            'false'.
-                        </xsd:documentation>
-                    </xsd:annotation>
-                </xsd:attribute>
+                <xsd:attributeGroup ref="smooks-dfdl:schemaURI"/>
+                <xsd:attributeGroup ref="smooks-dfdl:validateDFDLSchemas"/>
                 <xsd:attribute name="indent" type="xsd:boolean" default="false">
                     <xsd:annotation>
                         <xsd:documentation xml:lang="en">
@@ -72,14 +59,30 @@
                         </xsd:documentation>
                     </xsd:annotation>
                 </xsd:attribute>
-                <xsd:attribute name="schemaURI" type="xsd:string" use="required">
-                    <xsd:annotation>
-                        <xsd:documentation xml:lang="en">
-                            The URI of the DFDL schema.
-                        </xsd:documentation>
-                    </xsd:annotation>
-                </xsd:attribute>
+                <xsd:attributeGroup ref="smooks-dfdl:schemaURI"/>
+                <xsd:attributeGroup ref="smooks-dfdl:validateDFDLSchemas"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
+
+    <xsd:attributeGroup name="validateDFDLSchemas">
+        <xsd:attribute name="validateDFDLSchemas" type="xsd:boolean" default="false">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                    Enable/disable DFDL validation of resulting infoset with the DFDL schema. Default is
+                    'false'.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:attributeGroup>
+
+    <xsd:attributeGroup name="schemaURI">
+        <xsd:attribute name="schemaURI" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                    The URI of the DFDL schema.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:attributeGroup>
 </xsd:schema>

--- a/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd-smooks.xml
+++ b/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd-smooks.xml
@@ -5,54 +5,44 @@
     <resource-config selector="parser">
         <resource>org.milyn.cdr.extension.NewResourceConfig</resource>
     </resource-config>
-
     <resource-config selector="parser">
         <resource>org.milyn.cdr.extension.SetOnResourceConfig</resource>
         <param name="setOn">resourceType</param>
         <param name="value">dfdl-parser</param>
     </resource-config>
-
     <resource-config selector="parser">
         <resource>org.milyn.cdr.extension.SetOnResourceConfig</resource>
         <param name="setOn">selector</param>
         <param name="value">org.xml.sax.driver</param>
     </resource-config>
-
-    <resource-config selector="parser">
-        <resource>org.milyn.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">schemaURI</param>
-    </resource-config>
-
-    <resource-config selector="parser">
-        <resource>org.milyn.cdr.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">validateDFDLSchemas</param>
-    </resource-config>
-
     <resource-config selector="parser">
         <resource>org.milyn.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">indent</param>
     </resource-config>
 
+
     <resource-config selector="unparser">
         <resource>org.milyn.cdr.extension.NewResourceConfig</resource>
     </resource-config>
-
     <resource-config selector="unparser">
         <resource>org.milyn.cdr.extension.SetOnResourceConfig</resource>
         <param name="setOn">resourceType</param>
         <param name="value">dfdl-unparser</param>
     </resource-config>
-
     <resource-config selector="unparser">
         <resource>org.milyn.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">unparseOnElement</param>
         <param name="mapTo">selector</param>
     </resource-config>
 
-    <resource-config selector="unparser">
+
+    <resource-config selector="parser,unparser">
         <resource>org.milyn.cdr.extension.MapToResourceConfigFromAttribute</resource>
         <param name="attribute">schemaURI</param>
     </resource-config>
-
+    <resource-config selector="parser,unparser">
+        <resource>org.milyn.cdr.extension.MapToResourceConfigFromAttribute</resource>
+        <param name="attribute">validateDFDLSchemas</param>
+    </resource-config>
 
 </smooks-resource-list>

--- a/src/test/java/org/milyn/cartridges/dfdl/DFDLParserTestCase.java
+++ b/src/test/java/org/milyn/cartridges/dfdl/DFDLParserTestCase.java
@@ -27,8 +27,8 @@ public class DFDLParserTestCase {
         ProcessorFactory processorFactory = compiler.compileSource(getClass().getResource("/csv.dfdl.xsd").toURI());
         DataProcessor dataProcessor = processorFactory.onPath("/");
 
-        Map<String, DataProcessor> schemas = new HashMap<>();
-        schemas.put("classpath:/csv.dfdl.xsd", dataProcessor);
+        Map<String, DataProcessor> dataProcessors = new HashMap<>();
+        dataProcessors.put("/csv.dfdl.xsd", dataProcessor);
 
         ExecutionContext executionContext = new Smooks().createExecutionContext();
         executionContext.setAttribute(NamespaceDeclarationStack.class, new NamespaceDeclarationStack());
@@ -37,11 +37,11 @@ public class DFDLParserTestCase {
         SAXHandler saxHandler = new SAXHandler(executionContext, stringWriter);
 
         DFDLParser dfdlParser = new DFDLParser();
-        dfdlParser.setSchemaURI("classpath:/csv.dfdl.xsd");
+        dfdlParser.setDataProcessorName("/csv.dfdl.xsd");
         dfdlParser.setApplicationContext(new MockApplicationContext());
         dfdlParser.setIndent(true);
         dfdlParser.setContentHandler(saxHandler);
-        dfdlParser.getApplicationContext().setAttribute(AbstractDFDLContentHandlerFactory.class, schemas);
+        dfdlParser.getApplicationContext().setAttribute(AbstractDFDLContentHandlerFactory.class, dataProcessors);
 
         dfdlParser.initialize();
         dfdlParser.parse(new InputSource(getClass().getResourceAsStream("/simpleCSV.csv")));
@@ -55,8 +55,8 @@ public class DFDLParserTestCase {
         ProcessorFactory processorFactory = compiler.compileSource(getClass().getResource("/csv.dfdl.xsd").toURI());
         DataProcessor dataProcessor = processorFactory.onPath("/");
 
-        Map<String, DataProcessor> schemas = new HashMap<>();
-        schemas.put("classpath:/csv.dfdl.xsd", dataProcessor);
+        Map<String, DataProcessor> dataProcessors = new HashMap<>();
+        dataProcessors.put("/csv.dfdl.xsd", dataProcessor);
 
         ExecutionContext executionContext = new Smooks().createExecutionContext();
         executionContext.setAttribute(NamespaceDeclarationStack.class, new NamespaceDeclarationStack());
@@ -65,11 +65,11 @@ public class DFDLParserTestCase {
         SAXHandler saxHandler = new SAXHandler(executionContext, stringWriter);
 
         DFDLParser dfdlParser = new DFDLParser();
-        dfdlParser.setSchemaURI("classpath:/csv.dfdl.xsd");
+        dfdlParser.setDataProcessorName("/csv.dfdl.xsd");
         dfdlParser.setApplicationContext(new MockApplicationContext());
         dfdlParser.setIndent(false);
         dfdlParser.setContentHandler(saxHandler);
-        dfdlParser.getApplicationContext().setAttribute(AbstractDFDLContentHandlerFactory.class, schemas);
+        dfdlParser.getApplicationContext().setAttribute(AbstractDFDLContentHandlerFactory.class, dataProcessors);
 
         dfdlParser.initialize();
         dfdlParser.parse(new InputSource(getClass().getResourceAsStream("/simpleCSV.csv")));

--- a/src/test/resources/smooks-config.xml
+++ b/src/test/resources/smooks-config.xml
@@ -2,8 +2,8 @@
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-1.2.xsd"
                       xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
 
-    <dfdl:parser schemaURI="classpath:/csv.dfdl.xsd" indent="true"/>
+    <dfdl:parser schemaURI="/csv.dfdl.xsd" indent="true"/>
 
-    <dfdl:unparser schemaURI="classpath:/csv.dfdl.xsd" unparseOnElement="file"/>
+    <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnElement="file"/>
 
 </smooks-resource-list>


### PR DESCRIPTION
…Daffodil to retrieve the schema from the classpath; eliminated duplicate XSD definitions; refactored AbstractDFDLContentHandlerFactory in preparation for the EDIFACT cartridge; fixed bugs during parsing where the incorrect namespace URI was set on the element and the namespace declarations were incomplete