### PR TITLE
refactor!: rename unparseOnElement XML attribute to unparseOnNode for…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -119,7 +119,7 @@ Shown in the next snippet is the _dfdl:unparser_ visitor serialising the root el
 
     ...
 
-    <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnElement="file"/>
+    <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnNode="file"/>
 
 </smooks-resource-list>
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <gpg.skip>true</gpg.skip>
-        <smooks.version>2.0.0-M3</smooks.version>
+        <smooks.version>2.0.0-RC1-SNAPSHOT</smooks.version>
     </properties>
 
     <build>
@@ -204,6 +204,12 @@
             <groupId>org.apache.daffodil</groupId>
             <artifactId>daffodil-japi_2.12</artifactId>
             <version>3.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/org/smooks/cartridges/dfdl/DataProcessorFactory.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/DataProcessorFactory.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/main/java/org/smooks/cartridges/dfdl/DfdlSchema.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/DfdlSchema.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/main/java/org/smooks/cartridges/dfdl/MapToResourceConfigFromKeyValueAttributes.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/MapToResourceConfigFromKeyValueAttributes.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/main/java/org/smooks/cartridges/dfdl/parser/DfdlParser.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/parser/DfdlParser.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/main/java/org/smooks/cartridges/dfdl/parser/DfdlReaderConfigurator.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/parser/DfdlReaderConfigurator.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/main/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparser.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparser.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/main/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparserContentHandlerFactory.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparserContentHandlerFactory.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd
+++ b/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd
@@ -77,17 +77,10 @@
     </xsd:complexType>
 
     <xsd:attributeGroup name="unparserAttributes">
-        <xsd:attribute name="unparseOnElement" type="xsd:string">
+        <xsd:attribute name="unparseOnNode" type="xsd:string" use="required">
             <xsd:annotation>
                 <xsd:documentation xml:lang="en">
-                    The selector of the fragment to unparse.
-                </xsd:documentation>
-            </xsd:annotation>
-        </xsd:attribute>
-        <xsd:attribute name="distinguishedRootNode" type="xsd:string">
-            <xsd:annotation>
-                <xsd:documentation xml:lang="en">
-                    The selector of the fragment to unparse.
+                    The selector of the node to unparse.
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
@@ -97,7 +90,7 @@
         <xsd:attribute name="indent" type="xsd:boolean" default="false">
             <xsd:annotation>
                 <xsd:documentation xml:lang="en">
-                    Indent the generated event stream to make it easier to read. Useful for troublehsooting.
+                    Indent the generated event stream to make it easier to read. Useful for troubleshooting.
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>

--- a/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd-smooks.xml
+++ b/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd-smooks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
   ========================LICENSE_START=================================
-  smooks-dfdl-cartridge
+  Smooks DFDL Cartridge
   %%
   Copyright (C) 2020 Smooks
   %%
@@ -79,7 +79,7 @@
     </resource-config>
     <resource-config selector="dfdl:unparser">
         <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">unparseOnElement</param>
+        <param name="attribute">unparseOnNode</param>
         <param name="mapTo">selector</param>
     </resource-config>
     <resource-config selector="dfdl:unparser">

--- a/src/test/java/org/smooks/cartridges/dfdl/AbstractTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/AbstractTestCase.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/test/java/org/smooks/cartridges/dfdl/DfdlSchemaTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/DfdlSchemaTestCase.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/test/java/org/smooks/cartridges/dfdl/FunctionalTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/FunctionalTestCase.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%
@@ -48,9 +48,11 @@ import org.smooks.Smooks;
 import org.smooks.support.SmooksUtil;
 import org.smooks.support.StreamUtils;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FunctionalTestCase extends AbstractTestCase {
@@ -97,5 +99,10 @@ public class FunctionalTestCase extends AbstractTestCase {
         String result = SmooksUtil.filterAndSerialize(smooks.createExecutionContext(), getClass().getResourceAsStream("/data/simpleCSV.comma.csv"), smooks);
 
         assertTrue(StreamUtils.compareCharStreams(StreamUtils.readStreamAsString(getClass().getResourceAsStream("/data/simpleCSV.comma.csv"), "UTF-8"), result));
+    }
+
+    @Test
+    public void testSmooksConfigGivenMissingUnparseOnNodeAttributeOnDfdlUnparser() throws Exception {
+        assertThrows(SAXParseException.class, () -> smooks.addConfigurations("/smooks-missing-unparseOnNode-attribute-config.xml"));
     }
 }

--- a/src/test/java/org/smooks/cartridges/dfdl/TestKit.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/TestKit.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlReaderConfiguratorTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlReaderConfiguratorTestCase.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/test/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparserTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparserTestCase.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * smooks-dfdl-cartridge
+ * Smooks DFDL Cartridge
  * %%
  * Copyright (C) 2020 Smooks
  * %%

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ========================LICENSE_START=================================
-  smooks-dfdl-cartridge
+  Smooks DFDL Cartridge
   %%
   Copyright (C) 2020 Smooks
   %%

--- a/src/test/resources/smooks-cacheOnDisk-config.xml
+++ b/src/test/resources/smooks-cacheOnDisk-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
   ========================LICENSE_START=================================
-  smooks-dfdl-cartridge
+  Smooks DFDL Cartridge
   %%
   Copyright (C) 2020 Smooks
   %%
@@ -56,7 +56,7 @@
         </core:action>
         <core:config>
             <smooks-resource-list>
-                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnElement="*" cacheOnDisk="true"/>
+                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnNode="*" cacheOnDisk="true"/>
             </smooks-resource-list>
         </core:config>
     </core:smooks>

--- a/src/test/resources/smooks-debugging-config.xml
+++ b/src/test/resources/smooks-debugging-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
   ========================LICENSE_START=================================
-  smooks-dfdl-cartridge
+  Smooks DFDL Cartridge
   %%
   Copyright (C) 2020 Smooks
   %%
@@ -56,7 +56,7 @@
         </core:action>
         <core:config>
             <smooks-resource-list>
-                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnElement="*" debugging="true"/>
+                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnNode="*" debugging="true"/>
             </smooks-resource-list>
         </core:config>
     </core:smooks>

--- a/src/test/resources/smooks-missing-unparseOnNode-attribute-config.xml
+++ b/src/test/resources/smooks-missing-unparseOnNode-attribute-config.xml
@@ -3,7 +3,7 @@
   ========================LICENSE_START=================================
   Smooks DFDL Cartridge
   %%
-  Copyright (C) 2020 Smooks
+  Copyright (C) 2020 - 2021 Smooks
   %%
   Licensed under the terms of the Apache License Version 2.0, or
   the GNU Lesser General Public License version 3.0 or later.
@@ -43,22 +43,8 @@
   -->
 
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
-                      xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
                       xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
 
-    <dfdl:parser schemaURI="/csv.dfdl.xsd" indent="true"/>
-
-    <core:smooks filterSourceOn="#document">
-        <core:action>
-            <core:inline>
-                <core:replace/>
-            </core:inline>
-        </core:action>
-        <core:config>
-            <smooks-resource-list>
-                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnNode="*"/>
-            </smooks-resource-list>
-        </core:config>
-    </core:smooks>
+    <dfdl:unparser schemaURI="/csv.dfdl.xsd" />
 
 </smooks-resource-list>

--- a/src/test/resources/smooks-variables-config.xml
+++ b/src/test/resources/smooks-variables-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
   ========================LICENSE_START=================================
-  smooks-dfdl-cartridge
+  Smooks DFDL Cartridge
   %%
   Copyright (C) 2020 Smooks
   %%
@@ -60,7 +60,7 @@
         </core:action>
         <core:config>
             <smooks-resource-list>
-                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnElement="*">
+                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnNode="*">
                     <dfdl:variables>
                         <dfdl:variable name="{http://example.com}Delimiter" value="|"/>
                     </dfdl:variables>


### PR DESCRIPTION
… accuracy reasons

make unparseOnNode a required XML attribute

removed distinguishedRootNode attribute from XSD since it was added by mistake

bump Smooks from 2.0.0-M3 to 2.0.0-RC1-SNAPSHOT