### PR TITLE
feat: add support for Schematron validation in DFDL schema

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ The DFDL cartridge opens up Smooks to an incredible number of data formats (e.g.
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" xmlns:ex="http://example.com"
   targetNamespace="http://example.com" elementFormDefault="unqualified">
 
-  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormatPortable.dfdl.xsd" />
+  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd" />
 
   <xs:annotation>
     <xs:appinfo source="http://www.ogf.org/dfdl/">
@@ -70,14 +70,14 @@ A Smooks config parsing the above CSV using the DFDL cartridge would be written 
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
 
-    <dfdl:parser schemaURI="/csv.dfdl.xsd"/>
+    <dfdl:parser schemaUri="/csv.dfdl.xsd"/>
 
     ...
 
 </smooks-resource-list>
 ----
 
-`+dfdl:parser+` is a reader and its `+schemaURI+` attribute references the DFDL schema driving the parsing behaviour. Assuming _input.csv_ is the source, `+dfdl:parser+` will generate the event stream:
+`+dfdl:parser+` is a reader and its `+schemaUri+` attribute references the DFDL schema driving the parsing behaviour. Assuming _input.csv_ is the source, `+dfdl:parser+` will generate the event stream:
 
 [source,xml]
 ----
@@ -129,7 +129,7 @@ Shown in the next snippet is a https://github.com/smooks/smooks/blob/master/READ
         </core:action>
         <core:config>
             <smooks-resource-list>
-                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnNode="*"/>
+                <dfdl:unparser schemaUri="/csv.dfdl.xsd" unparseOnNode="*"/>
             </smooks-resource-list>
         </core:config>
     </core:smooks>
@@ -137,9 +137,187 @@ Shown in the next snippet is a https://github.com/smooks/smooks/blob/master/READ
 </smooks-resource-list>
 ----
 
-In contrast to the `+dfdl:parser+` `+schemaURI+` attribute , the `+schemaURI+` schema in `+dfdl:unparser+` drives the unparsing behaviour. `+dfdl:unparser+` replaces each node in the event stream with its serialized CSV counterpart, essentially implementing a passthrough application.
+In contrast to the `+dfdl:parser+` `+schemaUri+` attribute , the `+schemaUri+` schema in `+dfdl:unparser+` drives the unparsing behaviour. `+dfdl:unparser+` replaces each node in the event stream with its serialized CSV counterpart, essentially implementing a pass-through application.
 
 The DFDL cartridge supports variables, on disk caching, and trace debugging. Consult the link:src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd[XSD documentation] for further information.
+
+== Parser reader options
+
+=== Indent
+
+Indent the generated event stream to make it easier to read. Useful for troubleshooting. The default is `false`. Example:
+
+.smooks-config.xml
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
+
+    <dfdl:parser schemaUri="/csv.dfdl.xsd" indent="true"/>
+
+</smooks-resource-list>
+----
+
+=== Cache on disk
+
+Persist DFDL schema on disk to reduce compilation time in subsequent runs. The default value is `false`. Example:
+
+.smooks-config.xml
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
+
+    <dfdl:parser schemaUri="/csv.dfdl.xsd" cacheOnDisk="true"/>
+
+</smooks-resource-list>
+----
+
+=== Validation mode
+
+Validation modes for validating the resulting infoset against the DFDL schema. The following values are supported
+
+[cols="1,1"]
+|===
+| Value | Description
+
+| Off | Turn off all validation against the DFDL schema
+| Limited | Perform only facet validation
+| Full | Perform full schema validation using Xerces
+|===
+
+The default value is `Off`. Example:
+
+.smooks-config.xml
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
+
+    <dfdl:parser schemaUri="/csv.dfdl.xsd" validationMode="Limited"/>
+
+</smooks-resource-list>
+----
+
+=== Debugging
+
+Enable/disable trace debugging. The default value is `false`. Example:
+
+.smooks-config.xml
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
+
+    <dfdl:parser schemaUri="/csv.dfdl.xsd" debugging="true"/>
+
+</smooks-resource-list>
+----
+
+=== Schematron validation
+
+Apply standalone or embedded Schematron rules within the DFDL schema. Note that Schematron validation leads to the https://issues.apache.org/jira/browse/DAFFODIL-2386[input stream being loaded into memory] therefore such validation is not recommended for large streams.
+
+Standalone Schematron rules are applied like this:
+
+.smooks-config.xml
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
+
+    <dfdl:parser schemaUri="/csv.dfdl.xsd">
+        <dfdl:schematron url="rules.sch"/>
+    </dfdl:parser>
+
+</smooks-resource-list>
+----
+
+Embedded rules are applied as follows:
+
+.smooks-config.xml
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
+
+    <dfdl:parser schemaUri="/csv.dfdl.xsd">
+        <dfdl:schematron/>
+    </dfdl:parser>
+
+</smooks-resource-list>
+----
+
+Failed assertions do not interrupt the parsing and can be retrieved from the Smooks execution context as shown below:
+
+[source,java]
+----
+...
+
+org.smooks.Smooks smooks = new org.smooks.Smooks();
+org.smooks.api.ExecutionContext executionContext = smooks.createExecutionContext();
+smooks.filterSource(executionContext, source, result);
+
+List<org.apache.daffodil.japi.Diagnostic> diagnostics = executionContext.get(org.smooks.cartridges.dfdl.parser.DfdlParser.DIAGNOSTICS_TYPED_KEY);
+----
+
+== Unparser visitor options
+
+=== Cache on disk
+
+Persist DFDL schema on disk to reduce compilation time in subsequent runs. The default value is `false`. Example:
+
+.smooks-config.xml
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
+
+    <dfdl:unparser schemaUri="/csv.dfdl.xsd" unparseOnNode="*" cacheOnDisk="true"/>
+
+</smooks-resource-list>
+----
+
+=== Validation mode
+
+Validation modes for validating the resulting infoset against the DFDL schema. The following values are supported
+
+[cols="1,1"]
+|===
+| Value | Description
+
+| Off | Turn off all validation against the DFDL schema
+| Limited | Perform only facet validation
+| Full | Perform full schema validation using Xerces
+|===
+
+The default value is `Off`. Example:
+
+.smooks-config.xml
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
+
+    <dfdl:unparser schemaUri="/csv.dfdl.xsd" unparseOnNode="*" validationMode="Limited"/>
+
+</smooks-resource-list>
+----
+
+=== Debugging
+
+Enable/disable trace debugging. The default value is `false`. Example:
+
+.smooks-config.xml
+[source,xml]
+----
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+                      xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
+
+    <dfdl:unparser schemaUri="/csv.dfdl.xsd" unparseOnNode="*" debugging="true"/>
+
+</smooks-resource-list>
+----
 
 == Maven Coordinates
 

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,17 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.daffodil</groupId>
+            <artifactId>daffodil-schematron_2.12</artifactId>
+            <version>3.5.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.17.0</version>

--- a/src/main/java/org/smooks/cartridges/dfdl/DataProcessorFactory.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/DataProcessorFactory.java
@@ -70,7 +70,7 @@ public class DataProcessorFactory {
     protected ResourceConfig resourceConfig;
 
     @Inject
-    @Named("schemaURI")
+    @Named("schemaUri")
     protected String schemaUri;
 
     public DataProcessor createDataProcessor() {
@@ -84,7 +84,13 @@ public class DataProcessorFactory {
                 }
             }
 
-            final DfdlSchema dfdlSchema = new DfdlSchema(new URI(schemaUri), variables, ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")), Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")), Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")), resourceConfig.getParameterValue("distinguishedRootNode", String.class));
+            final DfdlSchema dfdlSchema = new DfdlSchema(new URI(schemaUri), variables,
+                    ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")),
+                    Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")),
+                    Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")),
+                    resourceConfig.getParameterValue("distinguishedRootNode", String.class),
+                    resourceConfig.getParameterValue("schematronUrl", String.class),
+                    Boolean.parseBoolean(resourceConfig.getParameterValue("schematronValidation", String.class)));
             return compileOrGet(dfdlSchema);
         } catch (Throwable t) {
             throw new SmooksConfigException(t);

--- a/src/main/java/org/smooks/cartridges/dfdl/parser/DfdlReaderConfigurator.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/parser/DfdlReaderConfigurator.java
@@ -56,7 +56,6 @@ import java.util.Map;
 public class DfdlReaderConfigurator implements ReaderConfigurator {
 
     protected final String schemaUri;
-
     protected Boolean debugging = false;
     protected Boolean cacheOnDisk = false;
     protected ValidationMode validationMode = ValidationMode.Off;
@@ -121,7 +120,7 @@ public class DfdlReaderConfigurator implements ReaderConfigurator {
     public List<ResourceConfig> toConfig() {
         final GenericReaderConfigurator genericReaderConfigurator = new GenericReaderConfigurator(DfdlParser.class);
 
-        genericReaderConfigurator.getParameters().setProperty("schemaURI", schemaUri);
+        genericReaderConfigurator.getParameters().setProperty("schemaUri", schemaUri);
         genericReaderConfigurator.getParameters().setProperty("validationMode", validationMode.toString());
         genericReaderConfigurator.getParameters().setProperty("cacheOnDisk", Boolean.toString(cacheOnDisk));
         genericReaderConfigurator.getParameters().setProperty("debugging", Boolean.toString(debugging));

--- a/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd
+++ b/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd
@@ -78,6 +78,7 @@
             <xsd:extension base="smooks:abstract-reader">
                 <xsd:sequence>
                     <xsd:element name="variables" type="dfdl:variables" minOccurs="0" maxOccurs="unbounded"/>
+                    <xsd:element name="schematron" type="dfdl:schematron" minOccurs="0"/>
                 </xsd:sequence>
                 <xsd:attributeGroup ref="dfdl:parserAttributes"/>
                 <xsd:attributeGroup ref="dfdl:parserUnparserAttributes"/>
@@ -118,6 +119,21 @@
         </xsd:sequence>
     </xsd:complexType>
 
+    <xsd:complexType name="schematron">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">
+                Apply standalone or embedded Schematron rules within the DFDL schema.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="url" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                    File URL for standalone Schematron
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
     <xsd:attributeGroup name="unparserAttributes">
         <xsd:attribute name="unparseOnNode" type="xsd:string" use="required">
             <xsd:annotation>
@@ -153,7 +169,7 @@
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
-        <xsd:attribute name="schemaURI" type="xsd:string" use="required">
+        <xsd:attribute name="schemaUri" type="xsd:string" use="required">
             <xsd:annotation>
                 <xsd:documentation xml:lang="en">
                     URI of the DFDL schema.

--- a/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd-smooks.xml
+++ b/src/main/resources/META-INF/xsd/smooks/dfdl-1.0.xsd-smooks.xml
@@ -89,7 +89,7 @@
 
     <resource-config selector="dfdl:parser,dfdl:unparser">
         <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
-        <param name="attribute">schemaURI</param>
+        <param name="attribute">schemaUri</param>
     </resource-config>
     <resource-config selector="dfdl:parser,dfdl:unparser">
         <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
@@ -110,4 +110,16 @@
         <param name="keyAttribute">name</param>
         <param name="valueAttribute">value</param>
     </resource-config>
+
+    <resource-config selector="dfdl:schematron">
+        <resource>org.smooks.engine.resource.extension.SetOnResourceConfig</resource>
+        <param name="setOn">schematronValidation</param>
+        <param name="value">true</param>
+    </resource-config>
+    <resource-config selector="dfdl:schematron">
+        <resource>org.smooks.engine.resource.extension.MapToResourceConfigFromAttribute</resource>
+        <param name="attribute">url</param>
+        <param name="mapTo">schematronUrl</param>
+    </resource-config>
+
 </smooks-resource-list>

--- a/src/test/java/org/smooks/cartridges/dfdl/DfdlSchemaTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/DfdlSchemaTestCase.java
@@ -59,7 +59,7 @@ public class DfdlSchemaTestCase extends AbstractTestCase {
     @Test
     public void testCompileHitsCacheGivenCacheOnDiskIsSetToTrue() throws Throwable {
         CountDownLatch countDownLatch = new CountDownLatch(2);
-        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), TestKit.getRandomItem(TestKit.getCacheOnDiskSupportedValidationModes()), true, ThreadLocalRandom.current().nextBoolean(), null) {
+        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), TestKit.getRandomItem(TestKit.getCacheOnDiskSupportedValidationModes()), true, ThreadLocalRandom.current().nextBoolean(), null, null, false) {
             @Override
             protected DataProcessor compileSource() throws Throwable {
                 countDownLatch.countDown();
@@ -74,14 +74,14 @@ public class DfdlSchemaTestCase extends AbstractTestCase {
 
     @Test
     public void testCompileGivenCacheOnDiskIsSetToTrue() throws Throwable {
-        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), TestKit.getRandomItem(TestKit.getCacheOnDiskSupportedValidationModes()), true, ThreadLocalRandom.current().nextBoolean(), null);
+        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), TestKit.getRandomItem(TestKit.getCacheOnDiskSupportedValidationModes()), true, ThreadLocalRandom.current().nextBoolean(), null, null, false);
         dfdlSchema.compile();
         assertTrue(new File(DfdlSchema.WORKING_DIRECTORY + "/csv.dfdl.xsd.dat").exists());
     }
 
     @Test
     public void testCompileGivenCacheOnDiskIsSetToFalse() throws Throwable {
-        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), ValidationMode.values()[ThreadLocalRandom.current().nextInt(ValidationMode.values().length)], false, ThreadLocalRandom.current().nextBoolean(), null);
+        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), ValidationMode.values()[ThreadLocalRandom.current().nextInt(ValidationMode.values().length)], false, ThreadLocalRandom.current().nextBoolean(), null, null, false);
         dfdlSchema.compile();
         assertFalse(new File(DfdlSchema.WORKING_DIRECTORY + "/csv.dfdl.xsd.dat").exists());
     }

--- a/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
@@ -63,6 +63,7 @@ import org.smooks.io.Stream;
 import org.smooks.namespace.NamespaceDeclarationStack;
 import org.smooks.support.StreamUtils;
 import org.smooks.tck.MockApplicationContext;
+import org.smooks.tck.MockExecutionContext;
 import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -177,13 +178,14 @@ public class DfdlParserTestCase extends AbstractTestCase {
     @Test
     public void testParseWhenParseError() throws Exception {
         ResourceConfig smooksResourceConfiguration = new DefaultResourceConfig();
-        smooksResourceConfiguration.setParameter("schemaURI", "");
+        smooksResourceConfiguration.setParameter("schemaUri", "");
 
         DfdlParser dfdlParser = new DfdlParser();
         dfdlParser.setDataProcessorFactoryClass(ParseErrorDataProcessorFactory.class);
         dfdlParser.setResourceConfig(smooksResourceConfiguration);
         dfdlParser.setApplicationContext(new MockApplicationContext());
         dfdlParser.setContentHandler(saxHandler);
+        dfdlParser.setExecutionContext(new MockExecutionContext());
 
         dfdlParser.postConstruct();
 
@@ -193,7 +195,7 @@ public class DfdlParserTestCase extends AbstractTestCase {
     @Test
     public void testParseWhenDiagnosticErrorButNotParseError() throws Exception {
         ResourceConfig resourceConfig = new DefaultResourceConfig();
-        resourceConfig.setParameter("schemaURI", "");
+        resourceConfig.setParameter("schemaUri", "");
 
         DfdlParser dfdlParser = new DfdlParser();
         dfdlParser.setDataProcessorFactoryClass(DiagnosticErrorDataProcessorFactory.class);
@@ -210,7 +212,7 @@ public class DfdlParserTestCase extends AbstractTestCase {
     @Test
     public void testParse() throws Exception {
         ResourceConfig resourceConfig = new DefaultResourceConfig();
-        resourceConfig.setParameter("schemaURI", "/csv.dfdl.xsd");
+        resourceConfig.setParameter("schemaUri", "/csv.dfdl.xsd");
 
         DfdlParser dfdlParser = new DfdlParser();
         dfdlParser.setDataProcessorFactoryClass(DataProcessorFactory.class);
@@ -228,7 +230,7 @@ public class DfdlParserTestCase extends AbstractTestCase {
     @Test
     public void testIncrementalParse() throws Exception {
         ResourceConfig resourceConfig = new DefaultResourceConfig();
-        resourceConfig.setParameter("schemaURI", "/csv.dfdl.xsd");
+        resourceConfig.setParameter("schemaUri", "/csv.dfdl.xsd");
 
         DfdlParser dfdlParser = new DfdlParser();
         dfdlParser.setDataProcessorFactoryClass(DataProcessorFactory.class);
@@ -248,7 +250,7 @@ public class DfdlParserTestCase extends AbstractTestCase {
     @Test
     public void testParseGivenIndentIsFalse() throws Exception {
         ResourceConfig resourceConfig = new DefaultResourceConfig();
-        resourceConfig.setParameter("schemaURI", "/csv.dfdl.xsd");
+        resourceConfig.setParameter("schemaUri", "/csv.dfdl.xsd");
 
         DfdlParser dfdlParser = new DfdlParser();
         dfdlParser.setDataProcessorFactoryClass(DataProcessorFactory.class);

--- a/src/test/resources/schematron/always-fails.sch
+++ b/src/test/resources/schematron/always-fails.sch
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            queryBinding="xslt2">
+
+    <sch:title>Sample Schematron using XPath 2.0</sch:title>
+    <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+
+    <sch:pattern>
+        <sch:rule context=".">
+            <sch:assert test="false()">never fails</sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
+</sch:schema>

--- a/src/test/resources/schematron/never-fails.sch
+++ b/src/test/resources/schematron/never-fails.sch
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            queryBinding="xslt2">
+
+    <sch:title>Sample Schematron using XPath 2.0</sch:title>
+    <sch:ns prefix="xs" uri="http://www.w3.org/2001/XMLSchema"/>
+
+    <sch:pattern>
+        <sch:rule context=".">
+            <sch:assert test="true()">always fails</sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
+</sch:schema>

--- a/src/test/resources/smooks-cacheOnDisk-config.xml
+++ b/src/test/resources/smooks-cacheOnDisk-config.xml
@@ -46,7 +46,7 @@
                       xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
                       xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
 
-    <dfdl:parser schemaURI="/csv.dfdl.xsd" cacheOnDisk="true"/>
+    <dfdl:parser schemaUri="/csv.dfdl.xsd" cacheOnDisk="true"/>
 
     <core:smooks filterSourceOn="#document">
         <core:action>
@@ -56,7 +56,7 @@
         </core:action>
         <core:config>
             <smooks-resource-list>
-                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnNode="*" cacheOnDisk="true"/>
+                <dfdl:unparser schemaUri="/csv.dfdl.xsd" unparseOnNode="*" cacheOnDisk="true"/>
             </smooks-resource-list>
         </core:config>
     </core:smooks>

--- a/src/test/resources/smooks-debugging-config.xml
+++ b/src/test/resources/smooks-debugging-config.xml
@@ -46,7 +46,7 @@
                       xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
                       xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
 
-    <dfdl:parser schemaURI="/csv.dfdl.xsd" debugging="true"/>
+    <dfdl:parser schemaUri="/csv.dfdl.xsd" debugging="true"/>
 
     <core:smooks filterSourceOn="#document">
         <core:action>
@@ -56,7 +56,7 @@
         </core:action>
         <core:config>
             <smooks-resource-list>
-                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnNode="*" debugging="true"/>
+                <dfdl:unparser schemaUri="/csv.dfdl.xsd" unparseOnNode="*" debugging="true"/>
             </smooks-resource-list>
         </core:config>
     </core:smooks>

--- a/src/test/resources/smooks-missing-unparseOnNode-attribute-config.xml
+++ b/src/test/resources/smooks-missing-unparseOnNode-attribute-config.xml
@@ -45,6 +45,6 @@
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
                       xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
 
-    <dfdl:unparser schemaURI="/csv.dfdl.xsd" />
+    <dfdl:unparser schemaUri="/csv.dfdl.xsd" />
 
 </smooks-resource-list>

--- a/src/test/resources/smooks-schematron-always-fails-config.xml
+++ b/src/test/resources/smooks-schematron-always-fails-config.xml
@@ -43,22 +43,10 @@
   -->
 
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
-                      xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
                       xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
 
-    <dfdl:parser schemaUri="/csv.dfdl.xsd" indent="true"  />
-
-    <core:smooks filterSourceOn="#document">
-        <core:action>
-            <core:inline>
-                <core:replace/>
-            </core:inline>
-        </core:action>
-        <core:config>
-            <smooks-resource-list>
-                <dfdl:unparser schemaUri="/csv.dfdl.xsd" unparseOnNode="*" />
-            </smooks-resource-list>
-        </core:config>
-    </core:smooks>
+    <dfdl:parser schemaUri="/csv.dfdl.xsd">
+        <dfdl:schematron url="schematron/always-fails.sch"/>
+    </dfdl:parser>
 
 </smooks-resource-list>

--- a/src/test/resources/smooks-schematron-never-fails-config.xml
+++ b/src/test/resources/smooks-schematron-never-fails-config.xml
@@ -43,22 +43,10 @@
   -->
 
 <smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
-                      xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
                       xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
 
-    <dfdl:parser schemaUri="/csv.dfdl.xsd" indent="true"  />
-
-    <core:smooks filterSourceOn="#document">
-        <core:action>
-            <core:inline>
-                <core:replace/>
-            </core:inline>
-        </core:action>
-        <core:config>
-            <smooks-resource-list>
-                <dfdl:unparser schemaUri="/csv.dfdl.xsd" unparseOnNode="*" />
-            </smooks-resource-list>
-        </core:config>
-    </core:smooks>
+    <dfdl:parser schemaUri="/csv.dfdl.xsd">
+        <dfdl:schematron url="schematron/never-fails.sch"/>
+    </dfdl:parser>
 
 </smooks-resource-list>

--- a/src/test/resources/smooks-variables-config.xml
+++ b/src/test/resources/smooks-variables-config.xml
@@ -46,7 +46,7 @@
                       xmlns:core="https://www.smooks.org/xsd/smooks/smooks-core-1.6.xsd"
                       xmlns:dfdl="https://www.smooks.org/xsd/smooks/dfdl-1.0.xsd">
 
-    <dfdl:parser schemaURI="/csv.dfdl.xsd">
+    <dfdl:parser schemaUri="/csv.dfdl.xsd">
         <dfdl:variables>
             <dfdl:variable name="{http://example.com}Delimiter" value="~"/>
         </dfdl:variables>
@@ -60,7 +60,7 @@
         </core:action>
         <core:config>
             <smooks-resource-list>
-                <dfdl:unparser schemaURI="/csv.dfdl.xsd" unparseOnNode="*">
+                <dfdl:unparser schemaUri="/csv.dfdl.xsd" unparseOnNode="*">
                     <dfdl:variables>
                         <dfdl:variable name="{http://example.com}Delimiter" value="|"/>
                     </dfdl:variables>


### PR DESCRIPTION
docs: document reader and visitor options

BREAKING CHANGE: rename dfdl:unparser and dfdl:parser `schemaURI` attribute to `schemaUri`