### PR TITLE
feat: set DFDL variables during execution instead of start-up so that…

### DIFF
--- a/src/main/java/org/smooks/cartridges/dfdl/DataProcessorFactory.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/DataProcessorFactory.java
@@ -48,14 +48,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smooks.api.ApplicationContext;
 import org.smooks.api.SmooksConfigException;
-import org.smooks.api.resource.config.Parameter;
 import org.smooks.api.resource.config.ResourceConfig;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -75,16 +72,7 @@ public class DataProcessorFactory {
 
     public DataProcessor createDataProcessor() {
         try {
-            final Map<String, String> variables = new HashMap<>();
-            final List<Parameter<?>> variablesParameters = resourceConfig.getParameters("variables");
-            if (variablesParameters != null) {
-                for (Parameter<?> variablesParameter : variablesParameters) {
-                    final Map.Entry<String, String> variable = (Map.Entry<String, String>) variablesParameter.getValue();
-                    variables.put(variable.getKey(), variable.getValue());
-                }
-            }
-
-            final DfdlSchema dfdlSchema = new DfdlSchema(new URI(schemaUri), variables,
+            final DfdlSchema dfdlSchema = new DfdlSchema(new URI(schemaUri),
                     ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")),
                     Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")),
                     Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")),

--- a/src/main/java/org/smooks/cartridges/dfdl/DfdlSchema.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/DfdlSchema.java
@@ -60,9 +60,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.channels.Channels;
 import java.nio.file.Files;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class DfdlSchema {
 
@@ -70,7 +68,6 @@ public class DfdlSchema {
     protected static final Logger LOGGER = LoggerFactory.getLogger(DfdlSchema.class);
 
     protected final URI uri;
-    protected final Map<String, String> variables;
     protected final ValidationMode validationMode;
     protected final boolean cacheOnDisk;
     protected final boolean debugging;
@@ -78,11 +75,10 @@ public class DfdlSchema {
     private final String schematronUrl;
     private final boolean schematronValidation;
 
-    public DfdlSchema(final URI uri, final Map<String, String> variables, final ValidationMode validationMode, final boolean cacheOnDisk,
+    public DfdlSchema(final URI uri, final ValidationMode validationMode, final boolean cacheOnDisk,
                       final boolean debugging, final String distinguishedRootNode, final String schematronUrl,
                       final boolean schematronValidation) {
         this.uri = uri;
-        this.variables = variables;
         this.validationMode = validationMode;
         this.cacheOnDisk = cacheOnDisk;
         this.debugging = debugging;
@@ -93,10 +89,6 @@ public class DfdlSchema {
 
     public URI getUri() {
         return uri;
-    }
-
-    public Map<String, String> getVariables() {
-        return variables;
     }
 
     public ValidationMode getValidationMode() {
@@ -112,7 +104,7 @@ public class DfdlSchema {
     }
 
     public String getName() {
-        return uri + ":" + validationMode + ":" + cacheOnDisk + ":" + debugging + ":" + variables.toString();
+        return uri + ":" + validationMode + ":" + cacheOnDisk + ":" + debugging;
     }
 
     public DataProcessor compile() throws Throwable {
@@ -137,7 +129,7 @@ public class DfdlSchema {
         }
 
 
-        dataProcessor = dataProcessor.withValidationMode(validationMode).withExternalVariables(new HashMap<>(variables));
+        dataProcessor = dataProcessor.withValidationMode(validationMode);
 
         if (schematronValidation) {
             final SchematronValidator schematronValidator;

--- a/src/main/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparserContentHandlerFactory.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparserContentHandlerFactory.java
@@ -53,21 +53,21 @@ import org.smooks.engine.lookup.LifecycleManagerLookup;
 
 import javax.inject.Inject;
 
-public class DfdlUnparserContentHandlerFactory implements ContentHandlerFactory<DfdlUnparser> {
+public class DfdlUnparserContentHandlerFactory<T extends DfdlUnparser> implements ContentHandlerFactory<DfdlUnparser> {
     
     @Inject
     protected ApplicationContext applicationContext;
 
     @Override
-    public DfdlUnparser create(final ResourceConfig smooksResourceConfiguration) throws SmooksConfigException {
+    public T create(final ResourceConfig resourceConfig) throws SmooksConfigException {
         try {
-            final String dataProcessorFactoryClassName = smooksResourceConfiguration.getParameterValue("dataProcessorFactory", String.class);
+            final String dataProcessorFactoryClassName = resourceConfig.getParameterValue("dataProcessorFactory", String.class);
             final Class<? extends DataProcessorFactory> dataProcessorFactoryClass = (Class<? extends DataProcessorFactory>) Class.forName(dataProcessorFactoryClassName);
             final DataProcessorFactory dataProcessorFactory = dataProcessorFactoryClass.newInstance();
 
-            applicationContext.getRegistry().lookup(new LifecycleManagerLookup()).applyPhase(dataProcessorFactory, new PostConstructLifecyclePhase(new Scope(applicationContext.getRegistry(), smooksResourceConfiguration, dataProcessorFactory)));
-            final DfdlUnparser dfdlUnparser = new DfdlUnparser(dataProcessorFactory.createDataProcessor());
-            applicationContext.getRegistry().lookup(new LifecycleManagerLookup()).applyPhase(dfdlUnparser, new PostConstructLifecyclePhase(new Scope(applicationContext.getRegistry(), smooksResourceConfiguration, dfdlUnparser)));
+            applicationContext.getRegistry().lookup(new LifecycleManagerLookup()).applyPhase(dataProcessorFactory, new PostConstructLifecyclePhase(new Scope(applicationContext.getRegistry(), resourceConfig, dataProcessorFactory)));
+            final T dfdlUnparser = newDfdlUnparser(dataProcessorFactory);
+            applicationContext.getRegistry().lookup(new LifecycleManagerLookup()).applyPhase(dfdlUnparser, new PostConstructLifecyclePhase(new Scope(applicationContext.getRegistry(), resourceConfig, dfdlUnparser)));
 
             return dfdlUnparser;
         } catch (Throwable t) {
@@ -86,5 +86,9 @@ public class DfdlUnparserContentHandlerFactory implements ContentHandlerFactory<
 
     public ApplicationContext getApplicationContext() {
         return applicationContext;
+    }
+
+    protected T newDfdlUnparser(DataProcessorFactory dataProcessorFactory) {
+        return (T) new DfdlUnparser(dataProcessorFactory.createDataProcessor());
     }
 }

--- a/src/test/java/org/smooks/cartridges/dfdl/DfdlSchemaTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/DfdlSchemaTestCase.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -59,7 +58,7 @@ public class DfdlSchemaTestCase extends AbstractTestCase {
     @Test
     public void testCompileHitsCacheGivenCacheOnDiskIsSetToTrue() throws Throwable {
         CountDownLatch countDownLatch = new CountDownLatch(2);
-        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), TestKit.getRandomItem(TestKit.getCacheOnDiskSupportedValidationModes()), true, ThreadLocalRandom.current().nextBoolean(), null, null, false) {
+        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), TestKit.getRandomItem(TestKit.getCacheOnDiskSupportedValidationModes()), true, ThreadLocalRandom.current().nextBoolean(), null, null, false) {
             @Override
             protected DataProcessor compileSource() throws Throwable {
                 countDownLatch.countDown();
@@ -74,14 +73,14 @@ public class DfdlSchemaTestCase extends AbstractTestCase {
 
     @Test
     public void testCompileGivenCacheOnDiskIsSetToTrue() throws Throwable {
-        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), TestKit.getRandomItem(TestKit.getCacheOnDiskSupportedValidationModes()), true, ThreadLocalRandom.current().nextBoolean(), null, null, false);
+        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), TestKit.getRandomItem(TestKit.getCacheOnDiskSupportedValidationModes()), true, ThreadLocalRandom.current().nextBoolean(), null, null, false);
         dfdlSchema.compile();
         assertTrue(new File(DfdlSchema.WORKING_DIRECTORY + "/csv.dfdl.xsd.dat").exists());
     }
 
     @Test
     public void testCompileGivenCacheOnDiskIsSetToFalse() throws Throwable {
-        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), ValidationMode.values()[ThreadLocalRandom.current().nextInt(ValidationMode.values().length)], false, ThreadLocalRandom.current().nextBoolean(), null, null, false);
+        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), ValidationMode.values()[ThreadLocalRandom.current().nextInt(ValidationMode.values().length)], false, ThreadLocalRandom.current().nextBoolean(), null, null, false);
         dfdlSchema.compile();
         assertFalse(new File(DfdlSchema.WORKING_DIRECTORY + "/csv.dfdl.xsd.dat").exists());
     }

--- a/src/test/java/org/smooks/cartridges/dfdl/FunctionalTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/FunctionalTestCase.java
@@ -139,7 +139,7 @@ public class FunctionalTestCase extends AbstractTestCase {
 
     @Test
     public void testSmooksGivenDfdlUnparserVisitor() throws Throwable {
-        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), new HashMap<>(), ValidationMode.Full, false, false, null, null, false);
+        DfdlSchema dfdlSchema = new DfdlSchema(new URI("/csv.dfdl.xsd"), ValidationMode.Full, false, false, null, null, false);
         DfdlUnparser dfdlUnparser = new DfdlUnparser(dfdlSchema.compile());
 
         smooks.setFilterSettings(FilterSettings.newSaxNgSettings().setDefaultSerializationOn(false));

--- a/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
@@ -70,7 +70,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
+import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -100,6 +102,11 @@ public class DfdlParserTestCase extends AbstractTestCase {
         public DataProcessor createDataProcessor() {
             return new DataProcessor(null) {
                 @Override
+                public DataProcessor withExternalVariables(AbstractMap<String, String> extVars) {
+                    return this;
+                }
+
+                @Override
                 public ParseResult parse(InputSourceDataInputStream input, InfosetOutputter output) {
                     return new ParseResult(null) {
                         @Override
@@ -109,7 +116,7 @@ public class DfdlParserTestCase extends AbstractTestCase {
 
                         @Override
                         public List<Diagnostic> getDiagnostics() {
-                            return Arrays.asList(new Diagnostic(null) {
+                            return Collections.singletonList(new Diagnostic(null) {
                                 @Override
                                 public String getSomeMessage() {
                                     return "";
@@ -141,6 +148,11 @@ public class DfdlParserTestCase extends AbstractTestCase {
         @Override
         public DataProcessor createDataProcessor() {
             return new DataProcessor(null) {
+                @Override
+                public DataProcessor withExternalVariables(AbstractMap<String, String> extVars) {
+                    return this;
+                }
+
                 @Override
                 public ParseResult parse(InputSourceDataInputStream input, InfosetOutputter output) {
                     return new ParseResult(null) {
@@ -177,16 +189,17 @@ public class DfdlParserTestCase extends AbstractTestCase {
 
     @Test
     public void testParseWhenParseErrorGivenValidationModeIsFull() throws Exception {
-        ResourceConfig smooksResourceConfiguration = new DefaultResourceConfig();
-        smooksResourceConfiguration.setParameter("schemaUri", "");
+        ResourceConfig resourceConfig = new DefaultResourceConfig();
+        resourceConfig.setParameter("schemaUri", "");
 
         DfdlParser dfdlParser = new DfdlParser();
         dfdlParser.setDataProcessorFactoryClass(ParseErrorDataProcessorFactory.class);
-        dfdlParser.setResourceConfig(smooksResourceConfiguration);
+        dfdlParser.setResourceConfig(resourceConfig);
         dfdlParser.setApplicationContext(new MockApplicationContext());
         dfdlParser.setContentHandler(saxHandler);
         dfdlParser.setExecutionContext(new MockExecutionContext());
         dfdlParser.setValidationMode(ValidationMode.Full);
+        dfdlParser.setResourceConfig(resourceConfig);
 
         dfdlParser.postConstruct();
 
@@ -203,6 +216,7 @@ public class DfdlParserTestCase extends AbstractTestCase {
         dfdlParser.setResourceConfig(resourceConfig);
         dfdlParser.setApplicationContext(new MockApplicationContext());
         dfdlParser.setContentHandler(saxHandler);
+        dfdlParser.setResourceConfig(resourceConfig);
 
         dfdlParser.postConstruct();
         dfdlParser.parse(new InputSource(new ByteArrayInputStream("".getBytes())));

--- a/src/test/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparserTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparserTestCase.java
@@ -44,13 +44,14 @@ package org.smooks.cartridges.dfdl.unparser;
 
 import org.apache.daffodil.japi.Daffodil;
 import org.apache.daffodil.japi.DataProcessor;
-import org.apache.daffodil.japi.ExternalVariableException;
 import org.apache.daffodil.japi.ProcessorFactory;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
 import org.dom4j.io.DOMWriter;
 import org.junit.jupiter.api.Test;
+import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.cartridges.dfdl.AbstractTestCase;
+import org.smooks.engine.resource.config.DefaultResourceConfig;
 import org.smooks.io.Stream;
 import org.smooks.tck.MockExecutionContext;
 import org.w3c.dom.Element;
@@ -61,7 +62,7 @@ import javax.xml.XMLConstants;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
-import java.util.HashMap;
+import java.util.AbstractMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -76,7 +77,7 @@ public class DfdlUnparserTestCase extends AbstractTestCase {
     private MockExecutionContext executionContext;
 
     @Override
-    public void doBeforeEach() throws DocumentException, URISyntaxException, IOException, ExternalVariableException {
+    public void doBeforeEach() throws DocumentException, URISyntaxException, IOException {
         executionContext = new MockExecutionContext();
         executionContext.put(Stream.STREAM_WRITER_TYPED_KEY, new StringWriter());
         
@@ -84,9 +85,10 @@ public class DfdlUnparserTestCase extends AbstractTestCase {
         ProcessorFactory processorFactory = compiler.compileSource(getClass().getResource("/csv.dfdl.xsd").toURI());
         DataProcessor dataProcessor = processorFactory.onPath("/");
 
-        dfdlUnparser = new DfdlUnparser(dataProcessor.withExternalVariables(new HashMap<String, String>() {{
-            this.put("{http://example.com}Delimiter", ",");
-        }}));
+        ResourceConfig resourceConfig = new DefaultResourceConfig();
+        resourceConfig.setParameter("variables", new AbstractMap.SimpleEntry<>("{http://example.com}Delimiter", ","));
+        dfdlUnparser = new DfdlUnparser(dataProcessor);
+        dfdlUnparser.setResourceConfig(resourceConfig);
         
         org.dom4j.Element document = DocumentHelper.createDocument().
                 addElement("ex:file", "http://example.com").


### PR DESCRIPTION
… the content-encoding can be set in the EDIFACT cartridge and fix smooks/smooks-edi-cartridge#224