### PR TITLE
fix: throw exception when the parse result is a parsing error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.6.3</version>
                 <configuration>
+                    <doclint>all,-missing</doclint>
                     <failOnError>false</failOnError>
                     <failOnWarnings>false</failOnWarnings>
                 </configuration>
@@ -176,6 +177,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
@@ -232,7 +240,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/smooks/cartridges/dfdl/DataProcessorFactory.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/DataProcessorFactory.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smooks.api.ApplicationContext;
 import org.smooks.api.SmooksConfigException;
+import org.smooks.api.SmooksException;
 import org.smooks.api.resource.config.ResourceConfig;
 
 import javax.inject.Inject;
@@ -71,18 +72,20 @@ public class DataProcessorFactory {
     protected String schemaUri;
 
     public DataProcessor createDataProcessor() {
+        final DfdlSchema dfdlSchema;
         try {
-            final DfdlSchema dfdlSchema = new DfdlSchema(new URI(schemaUri),
+            dfdlSchema = new DfdlSchema(new URI(schemaUri),
                     ValidationMode.valueOf(resourceConfig.getParameterValue("validationMode", String.class, "Off")),
                     Boolean.parseBoolean(resourceConfig.getParameterValue("cacheOnDisk", String.class, "false")),
                     Boolean.parseBoolean(resourceConfig.getParameterValue("debugging", String.class, "false")),
                     resourceConfig.getParameterValue("distinguishedRootNode", String.class),
                     resourceConfig.getParameterValue("schematronUrl", String.class),
                     Boolean.parseBoolean(resourceConfig.getParameterValue("schematronValidation", String.class)));
-            return compileOrGet(dfdlSchema);
         } catch (Throwable t) {
-            throw new SmooksConfigException(t);
+            throw new DfdlSmooksException(t);
         }
+        return compileOrGet(dfdlSchema);
+
     }
 
     protected DataProcessor compileOrGet(final DfdlSchema dfdlSchema) {
@@ -101,7 +104,7 @@ public class DataProcessorFactory {
             try {
                 return dfdlSchema.compile();
             } catch (Throwable t) {
-                throw new RuntimeException(t);
+                throw new DfdlSmooksException(t);
             }
         });
     }

--- a/src/main/java/org/smooks/cartridges/dfdl/DfdlSmooksException.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/DfdlSmooksException.java
@@ -1,0 +1,64 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Smooks DFDL Cartridge
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.cartridges.dfdl;
+
+import org.smooks.api.SmooksException;
+
+public class DfdlSmooksException extends SmooksException {
+
+    public DfdlSmooksException() {
+        super();
+    }
+
+    public DfdlSmooksException(String message) {
+        super(message);
+    }
+
+    public DfdlSmooksException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DfdlSmooksException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/smooks/cartridges/dfdl/parser/ContentHandlerInfosetOutputter.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/parser/ContentHandlerInfosetOutputter.java
@@ -47,7 +47,6 @@ import org.apache.daffodil.runtime1.infoset.DIArray;
 import org.apache.daffodil.runtime1.infoset.DIComplex;
 import org.apache.daffodil.runtime1.infoset.DIElement;
 import org.apache.daffodil.runtime1.infoset.DISimple;
-import org.smooks.api.SmooksException;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
@@ -67,7 +66,7 @@ class ContentHandlerInfosetOutputter extends InfosetOutputter {
     protected final boolean indent;
     protected int elementLevel = 0;
 
-    ContentHandlerInfosetOutputter(final ContentHandler contentHandler, boolean indent) {
+    ContentHandlerInfosetOutputter(ContentHandler contentHandler, boolean indent) {
         this.contentHandler = contentHandler;
         this.indent = indent;
     }
@@ -82,7 +81,7 @@ class ContentHandlerInfosetOutputter extends InfosetOutputter {
         try {
             contentHandler.startDocument();
         } catch (SAXException e) {
-            throw new SmooksException(e.getMessage(), e);
+            throw new ParserDfdlSmooksException(e.getMessage(), e);
         }
     }
 
@@ -91,12 +90,12 @@ class ContentHandlerInfosetOutputter extends InfosetOutputter {
         try {
             contentHandler.endDocument();
         } catch (SAXException e) {
-            throw new SmooksException(e.getMessage(), e);
+            throw new ParserDfdlSmooksException(e.getMessage(), e);
         }
     }
 
     @Override
-    public void startSimple(final DISimple diSimple) {
+    public void startSimple(DISimple diSimple) {
         try {
             final AttributesImpl attributes = createAttributes(diSimple);
             if (isNilled(diSimple)) {
@@ -108,21 +107,21 @@ class ContentHandlerInfosetOutputter extends InfosetOutputter {
                 contentHandler.characters(diSimple.dataValueAsString().toCharArray(), 0, diSimple.dataValueAsString().length());
             }
         } catch (Exception e) {
-            throw new SmooksException(e.getMessage(), e);
+            throw new ParserDfdlSmooksException(e.getMessage(), e);
         }
     }
 
     @Override
-    public void endSimple(final DISimple diSimple) {
+    public void endSimple(DISimple diSimple) {
         try {
             contentHandler.endElement(getNamespaceUri(diSimple), diSimple.erd().name(), getQName(diSimple));
         } catch (Exception e) {
-            throw new SmooksException(e.getMessage(), e);
+            throw new ParserDfdlSmooksException(e.getMessage(), e);
         }
     }
 
     @Override
-    public void startComplex(final DIComplex diComplex) {
+    public void startComplex(DIComplex diComplex) {
         try {
             indent(elementLevel);
             final String nsUri = getNamespaceUri(diComplex);
@@ -133,11 +132,11 @@ class ContentHandlerInfosetOutputter extends InfosetOutputter {
                 contentHandler.endElement(nsUri, diComplex.erd().name(), getQName(diComplex));
             }
         } catch (SAXException e) {
-            throw new SmooksException(e.getMessage(), e);
+            throw new ParserDfdlSmooksException(e.getMessage(), e);
         }
     }
 
-    protected AttributesImpl createAttributes(final DIElement diElement) {
+    protected AttributesImpl createAttributes(DIElement diElement) {
         final AttributesImpl attributes = new AttributesImpl();
         if (diElement.erd().namedQName().prefix().isDefined()) {
             final NamespaceBinding nsbStart = diElement.erd().minimizedScope();
@@ -154,36 +153,36 @@ class ContentHandlerInfosetOutputter extends InfosetOutputter {
     }
 
     @Override
-    public void endComplex(final DIComplex diComplex) {
+    public void endComplex(DIComplex diComplex) {
         try {
             elementLevel--;
             indent(elementLevel);
             contentHandler.endElement(diComplex.erd().targetNamespace().toString(), diComplex.erd().name(), getQName(diComplex));
         } catch (SAXException e) {
-            throw new SmooksException(e.getMessage(), e);
+            throw new ParserDfdlSmooksException(e.getMessage(), e);
         }
     }
 
     @Override
-    public void startArray(final DIArray diArray) {
+    public void startArray(DIArray diArray) {
     }
 
     @Override
-    public void endArray(final DIArray diArray) {
+    public void endArray(DIArray diArray) {
     }
 
-    protected String getQName(final DIElement diElement) {
+    protected String getQName(DIElement diElement) {
         final Option<String> prefix = diElement.erd().namedQName().prefix();
         return (prefix.isEmpty() || prefix.get().equals("")) ? "" : prefix.get() + ":" + diElement.erd().name();
     }
 
-    protected void indent(final int elementLevel) throws SAXException {
+    protected void indent(int elementLevel) throws SAXException {
         if (indent) {
             contentHandler.characters(INDENT, 0, elementLevel + 1);
         }
     }
 
-    protected String getNamespaceUri(final DIElement diElement) {
+    protected String getNamespaceUri(DIElement diElement) {
         return diElement.erd().namedQName().namespace().isNoNamespace() ? NULL_NS_URI : diElement.erd().namedQName().namespace().toString();
     }
 }

--- a/src/main/java/org/smooks/cartridges/dfdl/parser/DfdlParser.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/parser/DfdlParser.java
@@ -49,11 +49,11 @@ import org.apache.daffodil.japi.ExternalVariableException;
 import org.apache.daffodil.japi.ParseResult;
 import org.apache.daffodil.japi.ValidationMode;
 import org.apache.daffodil.japi.io.InputSourceDataInputStream;
+import org.apache.daffodil.runtime1.processors.parsers.ParseError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.smooks.api.ApplicationContext;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.SmooksException;
 import org.smooks.api.TypedKey;
 import org.smooks.api.resource.config.Parameter;
 import org.smooks.api.resource.config.ResourceConfig;
@@ -116,31 +116,31 @@ public class DfdlParser implements SmooksXMLReader {
     protected ExecutionContext executionContext;
 
     @Override
-    public void setExecutionContext(final ExecutionContext executionContext) {
+    public void setExecutionContext(ExecutionContext executionContext) {
         this.executionContext = executionContext;
     }
 
     @Override
-    public boolean getFeature(final String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+    public boolean getFeature(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
         return false;
     }
 
     @Override
-    public void setFeature(final String name, final boolean value) throws SAXNotRecognizedException, SAXNotSupportedException {
+    public void setFeature(String name, final boolean value) throws SAXNotRecognizedException, SAXNotSupportedException {
 
     }
 
     @Override
-    public Object getProperty(final String name) throws SAXNotRecognizedException, SAXNotSupportedException {
+    public Object getProperty(String name) throws SAXNotRecognizedException, SAXNotSupportedException {
         return null;
     }
 
     @Override
-    public void setProperty(final String name, final Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
+    public void setProperty(String name, final Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
     }
 
     @Override
-    public void setEntityResolver(final EntityResolver resolver) {
+    public void setEntityResolver(EntityResolver resolver) {
 
     }
 
@@ -150,7 +150,7 @@ public class DfdlParser implements SmooksXMLReader {
     }
 
     @Override
-    public void setDTDHandler(final DTDHandler dtdHandler) {
+    public void setDTDHandler(DTDHandler dtdHandler) {
         this.dtdHandler = dtdHandler;
     }
 
@@ -160,7 +160,7 @@ public class DfdlParser implements SmooksXMLReader {
     }
 
     @Override
-    public void setContentHandler(final ContentHandler contentHandler) {
+    public void setContentHandler(ContentHandler contentHandler) {
         this.contentHandler = contentHandler;
     }
 
@@ -170,7 +170,7 @@ public class DfdlParser implements SmooksXMLReader {
     }
 
     @Override
-    public void setErrorHandler(final ErrorHandler errorHandler) {
+    public void setErrorHandler(ErrorHandler errorHandler) {
         this.errorHandler = errorHandler;
     }
 
@@ -200,13 +200,13 @@ public class DfdlParser implements SmooksXMLReader {
     }
 
     @Override
-    public void parse(final InputSource input) {
+    public void parse(InputSource input) {
         InputStream inputStream = input.getByteStream();
         if (inputStream == null) {
             try {
                 inputStream = ReaderInputStream.builder().setReader(input.getCharacterStream()).get();
             } catch (IOException e) {
-                throw new SmooksException(e);
+                throw new ParserDfdlSmooksException(e);
             }
         }
 
@@ -215,7 +215,7 @@ public class DfdlParser implements SmooksXMLReader {
         try {
             copyDataProcessor = dataProcessor.withExternalVariables(getVariables());
         } catch (ExternalVariableException e) {
-            throw new SmooksException(e);
+            throw new ParserDfdlSmooksException(e);
         }
         ParseResult parseResult = null;
         while (parseResult == null || inputSourceDataInputStream.hasData()) {
@@ -224,8 +224,8 @@ public class DfdlParser implements SmooksXMLReader {
                 executionContext.put(DIAGNOSTICS_TYPED_KEY, parseResult.getDiagnostics());
                 for (Diagnostic diagnostic : parseResult.getDiagnostics()) {
                     if (diagnostic.isError()) {
-                        if (validationMode.equals(ValidationMode.Full)) {
-                            throw new SmooksException(diagnostic.getSomeMessage(), diagnostic.getSomeCause());
+                        if (validationMode.equals(ValidationMode.Full) || (diagnostic.getSomeCause() != null && diagnostic.getSomeCause() instanceof ParseError)) {
+                            throw new ParserDfdlSmooksException(diagnostic.getSomeMessage(), diagnostic.getSomeCause());
                         } else {
                             LOGGER.error(diagnostic.getSomeMessage());
                         }
@@ -234,7 +234,7 @@ public class DfdlParser implements SmooksXMLReader {
                     }
                 }
             } else {
-                for (final Diagnostic diagnostic : parseResult.getDiagnostics()) {
+                for (Diagnostic diagnostic : parseResult.getDiagnostics()) {
                     LOGGER.debug(diagnostic.getSomeMessage());
                 }
             }
@@ -242,7 +242,7 @@ public class DfdlParser implements SmooksXMLReader {
     }
 
     @Override
-    public void parse(final String systemId) {
+    public void parse(String systemId) {
 
     }
 
@@ -250,11 +250,11 @@ public class DfdlParser implements SmooksXMLReader {
         return applicationContext;
     }
 
-    public void setApplicationContext(final ApplicationContext applicationContext) {
+    public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
 
-    public void setIndent(final Boolean indent) {
+    public void setIndent(Boolean indent) {
         this.indent = indent;
     }
 
@@ -262,7 +262,7 @@ public class DfdlParser implements SmooksXMLReader {
         return dataProcessorFactoryClass;
     }
 
-    public void setDataProcessorFactoryClass(final Class<? extends DataProcessorFactory> dataProcessorFactoryClass) {
+    public void setDataProcessorFactoryClass(Class<? extends DataProcessorFactory> dataProcessorFactoryClass) {
         this.dataProcessorFactoryClass = dataProcessorFactoryClass;
     }
 
@@ -270,7 +270,7 @@ public class DfdlParser implements SmooksXMLReader {
         return resourceConfig;
     }
 
-    public void setResourceConfig(final ResourceConfig resourceConfig) {
+    public void setResourceConfig(ResourceConfig resourceConfig) {
         this.resourceConfig = resourceConfig;
     }
 
@@ -278,7 +278,7 @@ public class DfdlParser implements SmooksXMLReader {
         return schemaUri;
     }
 
-    public void setSchemaUri(final String schemaUri) {
+    public void setSchemaUri(String schemaUri) {
         this.schemaUri = schemaUri;
     }
 

--- a/src/main/java/org/smooks/cartridges/dfdl/parser/ParserDfdlSmooksException.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/parser/ParserDfdlSmooksException.java
@@ -1,0 +1,64 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Smooks DFDL Cartridge
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.cartridges.dfdl.parser;
+
+import org.smooks.cartridges.dfdl.DfdlSmooksException;
+
+public class ParserDfdlSmooksException extends DfdlSmooksException {
+
+    public ParserDfdlSmooksException() {
+        super();
+    }
+
+    public ParserDfdlSmooksException(String message) {
+        super(message);
+    }
+
+    public ParserDfdlSmooksException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ParserDfdlSmooksException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparser.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/unparser/DfdlUnparser.java
@@ -128,7 +128,7 @@ public class DfdlUnparser implements BeforeVisitor, AfterVisitor, ChildrenVisito
             writableByteChannel = Channels.newChannel(WriterOutputStream.builder().setCharset(executionContext.getContentEncoding()).setBufferSize(1024).setWriteImmediately(true).setWriter(Stream.out(executionContext)).get());
             daffodilUnparseContentHandler = dataProcessor.withExternalVariables(getVariables(executionContext)).newContentHandlerInstance(writableByteChannel);
         } catch (ExternalVariableException | IOException e) {
-            throw new SmooksException(e);
+            throw new UnparserDfdlSmooksException(e);
         }
         daffodilUnparseContentHandler.startDocument();
 
@@ -194,7 +194,7 @@ public class DfdlUnparser implements BeforeVisitor, AfterVisitor, ChildrenVisito
         if (unparseResult != null) {
             for (Diagnostic diagnostic : unparseResult.getDiagnostics()) {
                 if (diagnostic.isError()) {
-                    throw new SmooksException(diagnostic.getSomeMessage(), diagnostic.getSomeCause());
+                    throw new UnparserDfdlSmooksException(diagnostic.getSomeMessage(), diagnostic.getSomeCause());
                 } else {
                     LOGGER.warn(diagnostic.getMessage());
                 }

--- a/src/main/java/org/smooks/cartridges/dfdl/unparser/UnparserDfdlSmooksException.java
+++ b/src/main/java/org/smooks/cartridges/dfdl/unparser/UnparserDfdlSmooksException.java
@@ -1,0 +1,64 @@
+/*-
+ * ========================LICENSE_START=================================
+ * Smooks DFDL Cartridge
+ * %%
+ * Copyright (C) 2020 - 2024 Smooks
+ * %%
+ * Licensed under the terms of the Apache License Version 2.0, or
+ * the GNU Lesser General Public License version 3.0 or later.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-3.0-or-later
+ * 
+ * ======================================================================
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * ======================================================================
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * =========================LICENSE_END==================================
+ */
+package org.smooks.cartridges.dfdl.unparser;
+
+import org.smooks.cartridges.dfdl.DfdlSmooksException;
+
+public class UnparserDfdlSmooksException extends DfdlSmooksException {
+
+    public UnparserDfdlSmooksException() {
+        super();
+    }
+
+    public UnparserDfdlSmooksException(String message) {
+        super(message);
+    }
+
+    public UnparserDfdlSmooksException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnparserDfdlSmooksException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.smooks.Smooks;
 import org.smooks.api.ExecutionContext;
-import org.smooks.api.SmooksException;
 import org.smooks.api.resource.config.ResourceConfig;
 import org.smooks.cartridges.dfdl.AbstractTestCase;
 import org.smooks.cartridges.dfdl.DataProcessorFactory;
@@ -159,7 +158,7 @@ public class DfdlParserTestCase extends AbstractTestCase {
 
         dfdlParser.postConstruct();
 
-        assertThrows(SmooksException.class, () -> dfdlParser.parse(new InputSource(new ByteArrayInputStream("foo".getBytes()))));
+        assertThrows(ParserDfdlSmooksException.class, () -> dfdlParser.parse(new InputSource(new ByteArrayInputStream("foo".getBytes()))));
     }
 
     @Test

--- a/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
@@ -95,53 +95,6 @@ public class DfdlParserTestCase extends AbstractTestCase {
         saxHandler = new SaxNgContentHandler(executionContext, DocumentBuilderFactory.newInstance().newDocumentBuilder());
     }
 
-    public static class ParseErrorDataProcessorFactory extends DataProcessorFactory {
-
-        public ParseErrorDataProcessorFactory() {
-
-        }
-
-        @Override
-        public DataProcessor createDataProcessor() {
-            return new DataProcessor(null) {
-                @Override
-                public DataProcessor withExternalVariables(AbstractMap<String, String> extVars) {
-                    return this;
-                }
-
-                @Override
-                public ParseResult parse(InputSourceDataInputStream input, InfosetOutputter output) {
-                    return new ParseResult(null) {
-                        @Override
-                        public boolean isError() {
-                            return true;
-                        }
-
-                        @Override
-                        public List<Diagnostic> getDiagnostics() {
-                            return Collections.singletonList(new Diagnostic(null) {
-                                @Override
-                                public String getSomeMessage() {
-                                    return "";
-                                }
-
-                                @Override
-                                public Throwable getSomeCause() {
-                                    return new Throwable();
-                                }
-
-                                @Override
-                                public boolean isError() {
-                                    return true;
-                                }
-                            });
-                        }
-                    };
-                }
-            };
-        }
-    }
-
     public static class DiagnosticErrorDataProcessorFactory extends DataProcessorFactory {
 
         public DiagnosticErrorDataProcessorFactory() {

--- a/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
+++ b/src/test/java/org/smooks/cartridges/dfdl/parser/DfdlParserTestCase.java
@@ -50,6 +50,8 @@ import org.apache.daffodil.japi.infoset.InfosetOutputter;
 import org.apache.daffodil.japi.io.InputSourceDataInputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.smooks.Smooks;
 import org.smooks.api.ExecutionContext;
 import org.smooks.api.SmooksException;
@@ -73,7 +75,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.util.AbstractMap;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -166,7 +167,7 @@ public class DfdlParserTestCase extends AbstractTestCase {
 
                         @Override
                         public List<Diagnostic> getDiagnostics() {
-                            return Arrays.asList(new Diagnostic(null) {
+                            return Collections.singletonList(new Diagnostic(null) {
                                 @Override
                                 public String getSomeMessage() {
                                     return "";
@@ -189,23 +190,23 @@ public class DfdlParserTestCase extends AbstractTestCase {
         }
     }
 
-    @Test
-    public void testParseWhenParseErrorGivenValidationModeIsFull() throws Exception {
+    @ParameterizedTest
+    @EnumSource(value = ValidationMode.class)
+    public void testParseWhenParseError(ValidationMode validationMode) throws Exception {
         ResourceConfig resourceConfig = new DefaultResourceConfig();
-        resourceConfig.setParameter("schemaUri", "");
+        resourceConfig.setParameter("schemaUri", "/csv.dfdl.xsd");
 
         DfdlParser dfdlParser = new DfdlParser();
-        dfdlParser.setDataProcessorFactoryClass(ParseErrorDataProcessorFactory.class);
+        dfdlParser.setDataProcessorFactoryClass(DataProcessorFactory.class);
         dfdlParser.setResourceConfig(resourceConfig);
+        dfdlParser.setExecutionContext(new MockExecutionContext());
         dfdlParser.setApplicationContext(new MockApplicationContext());
         dfdlParser.setContentHandler(saxHandler);
-        dfdlParser.setExecutionContext(new MockExecutionContext());
-        dfdlParser.setValidationMode(ValidationMode.Full);
-        dfdlParser.setResourceConfig(resourceConfig);
+        dfdlParser.setValidationMode(validationMode);
 
         dfdlParser.postConstruct();
 
-        assertThrows(SmooksException.class, () -> dfdlParser.parse(new InputSource(new ByteArrayInputStream("".getBytes()))));
+        assertThrows(SmooksException.class, () -> dfdlParser.parse(new InputSource(new ByteArrayInputStream("foo".getBytes()))));
     }
 
     @Test
@@ -218,7 +219,6 @@ public class DfdlParserTestCase extends AbstractTestCase {
         dfdlParser.setResourceConfig(resourceConfig);
         dfdlParser.setApplicationContext(new MockApplicationContext());
         dfdlParser.setContentHandler(saxHandler);
-        dfdlParser.setResourceConfig(resourceConfig);
 
         dfdlParser.postConstruct();
         dfdlParser.parse(new InputSource(new ByteArrayInputStream("".getBytes())));


### PR DESCRIPTION
throw DfdlParserSmooksException and DfdlUnparserSmooksException instead of broad SmooksException

Refs: https://github.com/smooks/smooks-dfdl-cartridge/issues/191